### PR TITLE
Add conditions of use page and link to it from the footer

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -562,6 +562,7 @@ a.link_button_green_large {
 }
 
 .footer__about {
+  width: auto;
   h2 {
     color: $color_white;
   }

--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -5,4 +5,6 @@ Rails.application.routes.draw do
   # match '/mycontroller' => 'general#mycontroller'
   # Additional help page example
   # match '/help/help_out' => 'help#help_out'
+
+  match '/help/conditions' => 'help#conditions', :as => 'help_conditions'
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -16,4 +16,10 @@ Rails.configuration.to_prepare do
   #   def help_out
   #   end
   # end
+
+  HelpController.class_eval do
+    def conditions
+      @contact_email = AlaveteliConfiguration::contact_email
+    end
+  end
 end

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -1,0 +1,40 @@
+<div class="footer" id="footer" role="contentinfo">
+  <div class="row">
+    <div class="footer__about">
+      <h2><%= site_name %></h2>
+      <%= render :partial => 'general/responsive_credits' %>
+      <ul class="about__contact-links">
+        <li>
+          <%= link_to _('Contact us'), help_contact_path %>
+        </li>
+        <li>
+          <%= link_to _('Help'), help_path %>
+        </li>
+        <li>
+          <%= link_to _('Privacy and cookies'), help_privacy_path %>
+        </li>
+        <li>
+          <%= link_to _('API'), help_api_path %>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="footer__final">
+    <div class="row">
+      <div class="final__social-links">
+        <ul>
+          <% unless AlaveteliConfiguration::twitter_username.blank? %>
+          <li>
+            <a href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>" class="social-link social-link--twitter" onclick="<%= track_analytics_event(AnalyticsEvent::Category::OUTBOUND, AnalyticsEvent::Action::TWITTER_EXIT, :label => "Footer link")%>">@<%= AlaveteliConfiguration::twitter_username %></a>
+          </li>
+          <% end %>
+          <% unless AlaveteliConfiguration::facebook_username.blank? %>
+          <li>
+            <a href="https://facebook.com/<%= AlaveteliConfiguration::facebook_username %>" class="social-link social-link--facebook" onclick="<%= track_analytics_event(AnalyticsEvent::Category::OUTBOUND, AnalyticsEvent::Action::FACEBOOK_EXIT, :label => "Footer link")%>">/<%= AlaveteliConfiguration::facebook_username %></a>
+          </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/views/general/_responsive_footer.html.erb
+++ b/lib/views/general/_responsive_footer.html.erb
@@ -16,6 +16,9 @@
         <li>
           <%= link_to _('API'), help_api_path %>
         </li>
+        <li>
+          <%= link_to "Conditions d’utilisation", help_conditions_path %>
+        </li>
       </ul>
     </div>
   </div>

--- a/lib/views/help/_sidebar.html.erb
+++ b/lib/views/help/_sidebar.html.erb
@@ -9,6 +9,7 @@
   <li><%= link_to_unless_current "Credits", help_credits_path %></li>
   <li><%= link_to_unless_current "Programmers API", help_api_path %></li>
   <li><%= link_to_unless_current "Advanced search", advanced_search_path %></li>
+  <li><%= link_to_unless_current "Conditions d’utilisation", help_conditions_path %></li>
 </ul>
 
 <h2 id="contact" class="contact">Contact us</h2>

--- a/lib/views/help/conditions.html.erb
+++ b/lib/views/help/conditions.html.erb
@@ -1,0 +1,67 @@
+
+<% @title = "Conditions d’utilisation" %>
+
+<%= render :partial => 'sidebar' %>
+
+<div id="left_column_flip" class="left_column_flip">
+  <h1 id="conditions"><%= @title %> <a href="#conditions">#</a></h1>
+
+<p><%= site_name %> est une plateforme technique d’envoi de messages des demandeurs vers les autorités publiques et un hébergeur des réponses des autorités publiques.</p>
+
+<p>L'accès et l’utilisation de ce site est gratuit mais sa simple utilisation et/ou consultation implique, de façon automatique et inconditionnelle, votre pleine et entière acceptation de l'ensemble des conditions générales d'utilisation reprises ci-dessous.</p>
+
+<p>Le plus grand soin a été apporté à la création du site et à son contenu. Nous ne pouvons toutefois garantir l'exactitude, l'exhaustivité ou la mise à jour des données et des informations qui sont présentées et nous déclinons toute responsabilité quant au contenu du site ainsi qu'aux éventuelles erreurs, inexactitudes ou omissions affectant les données et informations diffusées.</p>
+
+<p>Sous réserve des dispositions légales et réglementaires applicables, nous ne saurions être tenus pour responsables des dommages, directs ou indirects, pouvant résulter de l'utilisation et/ou de la consultation du site, et plus généralement, de tout événement ayant un lien avec le site.</p>
+
+<p>En particulier, notre responsabilité ne saurait être engagée en cas de piratage total ou partiel du site et des conséquences que ce piratage pourrait entraîner.</p>
+
+<p>Nous nous réservons le droit de modifier, d'interrompre temporairement ou de manière permanente, tout ou partie du site, et ce sans aucun préavis.</p>
+
+<p>Les messages envoyés par les demandeurs et les réponses reçues par les autorités publiques sont automatiquement publiés, en libre accès, sur le site et sont donc accessibles sur Internet. Les messages ne sont ni lus, ni édités, ni vérifiés par <%= site_name %> avant publication. En conséquence <%= site_name %> ne pourra pas être tenu responsable du contenu des messages envoyés par les demandeurs et/ou des réponses reçues par les autorités publiques.</p>
+
+<p>Nous ferons toutefois le nécessaire pour supprimer rapidement toute demande d’un demandeur, réponse d’une autorité publique ou commentaire d’un utilisateur qui nous serait signalé comme non conforme à la législation. Veuillez nous contacter via <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a> en nous donnant toutes les informations utiles pour identifier le contenu que vous souhaitez nous signaler.</p>
+
+<p>Pour effectuer une demande à un autorité publique, les utilisateurs doivent s’identifier avec leur identité réelle. L’utilisation d’un pseudonyme ou de l’identité d’un tier est interdit.</p>
+
+<p><i>Obligations des visiteurs :</i></p>
+
+<p>
+Les utilisateurs s’engagent à dédommager <%= site_name %> contre toute réclamation d'un tiers, responsabilité, perte et frais (y compris dommages-intérêts et frais d'avocat) résultant d’une utilisation non conforme du site. Les utilisations conformes sont décrites dans ces Conditions d’utilisation et dans les pages d’Aide du site.
+</p>
+
+<p><em>Propriété intellectuelle :</em></p>
+
+<p>Les contenus présent dans ce site sont protégés par le droit d'auteur et/ou le droit des bases de données. Sous réserve des dispositions légales et réglementaires applicables, la reproduction, la diffusion ou la commercialisation, sur tout support, d'un élément constitutif du site, sans l'autorisation écrite préalable de l'éditeur du site est interdite et constitue une contrefaçon pouvant engager la responsabilité civile et pénale du contrefacteur</p>
+
+<p><em>Hyperliens :</em></p>
+
+<p>La présence d'un lien vers un site externe ne constitue pas une reconnaissance de sa conformité avec la législation en vigueur et/ou de la qualité des services et des produits fournis par l’organisme responsable du site. Nous ne saurions être tenus responsables des dommages pouvant résulter de sa consultation.</p>
+
+<p><em>Politique de modération des commentaires :</em></p>
+
+<p>Les commentaires sont publiés automatiquement. Ils peuvent faire l'objet d'une modération à posteriori. Le choix de supprimer et/ou d'éditer un commentaire est laissé à l'entière appréciation de l'éditeur du site sans que celui-ci n'ait à justifier son choix. Les commentaires n'implique aucune approbation de l'éditeur du site quant à leur contenu. En publiant un commentaire vous assurez la responsabilité juridique de son contenu. Vous acceptez également d'indemniser et de garantir l'éditeur du site contre toute réclamation, action en responsabilité, perte et frais (y compris les dommages-intérêts, les frais de transaction et, dans la limite du raisonnable, les frais de justice) pouvant être engagés contre ou subis par l'éditeur du site, et qui concernerait, résulterait ou pourrait résulter de votre commentaire.</p>
+
+<p>Si vous rencontrez un commentaire inapproprié merci de nous avertir via <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a></p>
+
+<p><em>Droit de rectification :</em></p>
+
+<p>Conformément aux dispositions légales toutes les personnes peuvent faire rectifier, sans frais, les données qui les concernent et qui s'avéreraient inexactes, incorrectes ou incomplètes. Contactez-nous via <a href="mailto:<%=@contact_email%>"><%=@contact_email%></a> afin d'être informé de la procédure de rectification.</p>
+
+<p><em>Dispositions diverses :</em></p>
+
+<p>Les informations que vous nous communiquez sur base volontaire (nom, prénom, email,...) par exemple via l'utilisation d'un formulaire de contact ou autre peuvent être encodées dans des fichiers de base de données. Ces informations serviront à l'usage exclusif de l'éditeur du site. Elles ne seront pas transmises à des tiers. La seule exception à ce principe réside dans les demandes de communication de ces informations à l'initiative des autorités habilitées à les formuler.</p>
+
+<p>Sauf dispositions d'ordre public, tout litige qui pourrait survenir dans le cadre de l'exécution des présentes conditions générales d'utilisation devra avant toute action judiciaire être soumis à l'éditeur du site en vue d'un éventuel règlement amiable ou d’une médiation judiciaire.</p>
+
+<p>Ces conditions générales d'utilisation peuvent faire l'objet de modifications à tout moment et ce sans préavis ni indemnités quelconques. Nous vous recommandons dès lors de les consulter régulièrement. Les conditions générales d'utilisation applicables à l'utilisateur sont celles en vigueur au moment de sa connexion au site.</p>
+
+<p>Les droits et recours contenus dans ce contrat sont cumulatifs à tous les droits et recours prévus par la loi.</p>
+
+<p>Si l'une des clauses des présentes conditions générales d'utilisation venait à être déclarée nulle par une décision de justice, cette nullité ne saurait emporter la nullité de l'ensemble des autres clauses, qui continueraient à produire pleinement leur effet.</p>
+
+<p>Ce site est soumis à l'application du droit belge. En cas de litige seuls les tribunaux francophones de l'arrondissement de Bruxelles seront compétents.</p>
+
+<p>Ce site n'est pas une publication officielle et ne peut en aucun cas être considéré comme un substitut aux publications officielles.</p>
+
+</div>


### PR DESCRIPTION
Not sure whether I was meant to take the formatting literally when dealing with what look like subheadings in italics. Have made the text italic but not a proper `<h2>` subheading.  This may not be correct.

Have also had to remove the width restriction from the `footer__about` section which is worth noting but probably ok.

Fixes #14 