### PR TITLE
Add dual language footer text to authority emails

### DIFF
--- a/lib/views/outgoing_mailer/followup.text.erb
+++ b/lib/views/outgoing_mailer/followup.text.erb
@@ -1,0 +1,10 @@
+<%= raw @outgoing_message.body.strip %>
+
+<%= raw @outgoing_message.quoted_part_to_append_to_email.strip %>
+
+-------------------------------------------------------------------
+<%= _('Please use this email address for all replies to this request:')%>
+<%= @info_request.incoming_email %>
+
+<%= render :partial => 'followup_footer' %>
+-------------------------------------------------------------------

--- a/lib/views/outgoing_mailer/followup.text.erb
+++ b/lib/views/outgoing_mailer/followup.text.erb
@@ -3,8 +3,16 @@
 <%= raw @outgoing_message.quoted_part_to_append_to_email.strip %>
 
 -------------------------------------------------------------------
+<% [:fr_BE, :nl_BE].each_with_index do |locale, i| %>
+  <% I18n.with_locale(locale) do %>
+
 <%= _('Please use this email address for all replies to this request:')%>
 <%= @info_request.incoming_email %>
 
 <%= render :partial => 'followup_footer' %>
+  <% end %>
+  <% if i < 1 %>
+--------------
+  <% end %>
+<% end %>
 -------------------------------------------------------------------

--- a/lib/views/outgoing_mailer/initial_request.text.erb
+++ b/lib/views/outgoing_mailer/initial_request.text.erb
@@ -1,0 +1,18 @@
+<%= raw @outgoing_message.body.strip %>
+
+-------------------------------------------------------------------
+
+<%= _('Please use this email address for all replies to this request:')%>
+<%= @info_request.incoming_email %>
+
+<%= _('Is {{email_address}} the wrong address for {{type_of_request}} ' \
+      'requests to {{public_body_name}}? If so, please contact us using ' \
+      'this form:',
+      :email_address => @info_request.public_body.request_email.html_safe,
+      :type_of_request => @info_request.law_used_human(:full).html_safe,
+      :public_body_name => @info_request.public_body.name.html_safe) %>
+<%= new_change_request_url(:body => @info_request.public_body.url_name) %>
+
+<%= render :partial => 'followup_footer' %>
+
+-------------------------------------------------------------------

--- a/lib/views/outgoing_mailer/initial_request.text.erb
+++ b/lib/views/outgoing_mailer/initial_request.text.erb
@@ -1,6 +1,8 @@
 <%= raw @outgoing_message.body.strip %>
 
 -------------------------------------------------------------------
+<% [:fr_BE, :nl_BE].each_with_index do |locale, i| %>
+  <% I18n.with_locale(locale) do %>
 
 <%= _('Please use this email address for all replies to this request:')%>
 <%= @info_request.incoming_email %>
@@ -14,5 +16,9 @@
 <%= new_change_request_url(:body => @info_request.public_body.url_name) %>
 
 <%= render :partial => 'followup_footer' %>
-
+  <% end %>
+  <% if i < 1 %>
+--------------
+  <% end %>
+<% end %>
 -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #43 

Footer text content remains in Transifex

(Need to check that the dual language footer for followup mails is required - I _think_ it is - and whether the current text is sufficient or needs to be the same as the initial request version)