### PR TITLE
Improve the way the theme loads translations to not clash with pro

### DIFF
--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -61,9 +61,21 @@ Rails.application.config.assets.precompile.unshift(LOOSE_THEME_ASSETS)
 # Tell FastGettext about the theme's translations: look in the theme's
 # locale-theme directory for a translation in the first place, and if
 # it isn't found, look in the Alaveteli locale directory next:
-repos = [
-  FastGettext::TranslationRepository.build('app', :path=>File.join(File.dirname(__FILE__), '..', 'locale-theme'), :type => :po),
-  FastGettext::TranslationRepository.build('app', :path=>'locale', :type => :po)
-]
-FastGettext.add_text_domain 'app', :type=>:chain, :chain=>repos
+repos = [ FastGettext::TranslationRepository.
+            build('app',
+                  :path => File.join(File.dirname(__FILE__), '..', 'locale-theme'),
+                  :type => :po)
+        ]
+if AlaveteliConfiguration::enable_alaveteli_pro
+  pro_repo = FastGettext::TranslationRepository.build('app',
+    :path => 'locale_alaveteli_pro',
+    :type => :po)
+  repos << pro_repo
+end
+repos << FastGettext::TranslationRepository.build(
+           'app',
+           :path => 'locale',
+           :type => :po)
+
+FastGettext.add_text_domain 'app', :type=> :chain, :chain=> repos
 FastGettext.default_text_domain = 'app'

--- a/lib/alavetelitheme.rb
+++ b/lib/alavetelitheme.rb
@@ -77,5 +77,4 @@ repos << FastGettext::TranslationRepository.build(
            :path => 'locale',
            :type => :po)
 
-FastGettext.add_text_domain 'app', :type=> :chain, :chain=> repos
-FastGettext.default_text_domain = 'app'
+AlaveteliLocalization.set_default_text_domain('app', repos)


### PR DESCRIPTION
This is a quick fix to prevent the theme unintentionally removing the
pro translations from the translation repository chain.

It's similar to the [fix for ipvtheme](https://github.com/mysociety/ipvtheme/commit/2e9bc29877c57fa234e03e75c9c8c480a789cb39) but is trying to be mindful of the loading order which affects which set of translations takes precedence.