### PR TITLE
Allow the widget button text to break over 2 lines

### DIFF
--- a/app/assets/stylesheets/widget.scss
+++ b/app/assets/stylesheets/widget.scss
@@ -213,4 +213,5 @@ a:active {
 .alaveteli-widget__button--create-track,
 .alaveteli-widget__button--create-vote {
   @extend .alaveteli-widget__button;
+  white-space: normal;
 }


### PR DESCRIPTION
## Why was this needed? 

Otherwise the French translation of "I would also like to know" gets truncated.

## Notes to reviewer

Tested using Browserstack - works on IE, Edge, Chrome and Firefox on Windows (as well as the usual suspects on my Mac). The longer French text splits over 2 lines, the shorter Dutch translation is unaffected.

<img width="339" alt="screen shot 2018-08-20 at 15 26 37" src="https://user-images.githubusercontent.com/27760/44346287-7f6d1780-a48d-11e8-9d68-e6aa487ff824.png">

<img width="344" alt="screen shot 2018-08-20 at 15 26 23" src="https://user-images.githubusercontent.com/27760/44346291-81cf7180-a48d-11e8-9ef6-90ef0357154c.png">

## Related ticket(s)

Fixes #90 