### PR TITLE
Set province when creating the internal admin user

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -64,7 +64,8 @@ Rails.configuration.to_prepare do
           :name => 'Internal admin user',
           :email => AlaveteliConfiguration.contact_email,
           :password => password,
-          :password_confirmation => password
+          :password_confirmation => password,
+          :province => 'Bruxelles'
         )
         user.save!
       end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -55,6 +55,23 @@ Rails.configuration.to_prepare do
       end
     end
 
+    # The "internal admin" is a special user for internal use.
+    def self.internal_admin_user
+      user = User.find_by_email(AlaveteliConfiguration::contact_email)
+      if user.nil?
+        password = PostRedirect.generate_random_token
+        user = User.new(
+          :name => 'Internal admin user',
+          :email => AlaveteliConfiguration.contact_email,
+          :password => password,
+          :password_confirmation => password
+        )
+        user.save!
+      end
+
+      user
+    end
+
     private
 
     def province_not_removed

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,4 +25,16 @@ describe User do
     expect(user.valid?).to be true
   end
 
+  describe '.internal_admin_user' do
+
+    before do
+      User.find_by_email(AlaveteliConfiguration.contact_email).try(:destroy)
+    end
+
+    it 'sets the province when creating a new internal admin user' do
+      expect(User.internal_admin_user.province).to eq('Bruxelles')
+    end
+
+  end
+
 end


### PR DESCRIPTION
Otherwise `user.save!` will fail as the theme adds province to the `User model` as a required field

Fixes #67