### PR TITLE
Apply header changes from core

### DIFF
--- a/app/assets/stylesheets/responsive/custom.scss
+++ b/app/assets/stylesheets/responsive/custom.scss
@@ -272,58 +272,108 @@ a.link_button_green_large {
 }
 
 /* Vertically align the search box */
-#navigation_search{
-  input{
-    margin-top:0.313em;
-    margin-bottom:0.313em;
-    height: 1.875em;
-    @include ie8 {
-      height: 33px;
-      font-size: 1.1em;
-      padding: 0;
-    }
+#navigation_search {
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    padding-top: 2em;
   }
 }
 
-#navigation_search_button{
-  background-color: $color_white;
-  border: none;
-  transition: all 0.3s ease-out;
-  color: $color_primary;
-  border-radius: 0;
-  font-size: inherit;
+#navigation_search_form {
+  position: relative;
 }
+
 
 .js-loaded {
   .account-link {
     padding-right: 2em;
+    &:after {
+      border-top-color: rgba(255,255,255,0.4);
+    }
+  }
+  .account-link--with-pro-pill {
+    padding-right: 3em;
+  }
+}
+
+.logged-in-menu {
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    color: black;
+    box-shadow: 0 3px 15px 0 rgba(0, 0, 0, 0.1);
+  }
+  li {
+    border-top: 1px solid rgba(255, 255, 255, 0.2);
+  }
+  a,
+  a:visited {
+    color: #fff;
+    cursor: pointer;
+    text-decoration: none;
+    &:hover,
+    &:active,
+    &:focus {
+      color: #fff;
+      background-color: rgba(0, 0, 0, 0.1);
+    }
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      //make it appear like it's aligned with the grid, even though it isn't
-      margin-right: 0.935em;
-      &:after {
-        top: 2em;
+      color: $link-color;
+      &:hover,
+      &:active,
+      &:focus {
+        color: $color_black;
+        background-color: transparent;
+        text-decoration: underline;
+      }
+    }
+    .alaveteli-pro & {
+      @include respond-min( $main_menu-mobile_menu_cutoff ){
+        color: $link-color;
+        &:hover,
+        &:active,
+        &:focus {
+          color: $color_black;
+        }
       }
     }
   }
 }
 
-.no-js {
-  .navigation .logged-in-menu a,
-  .navigation .logged-in-menu__signout-link a {
-    @extend %menu-item;
+.alaveteli-pro .account-link,
+.alaveteli-pro .account-link:visited,
+.account-link,
+.account-link:link,
+.account-link:visited,
+.sign_in_link,
+.sign_in_link:link,
+.sign_in_link:visited {
+  color: #fff;
+  text-decoration: none;
+  &:hover,
+  &:active,
+  &:focus {
+    color: #fff;
   }
 }
 
-.js-loaded {
-  .navigation .logged-in-menu__signout-link a {
-    @include respond-min( $main_menu-mobile_menu_cutoff ){
-      text-transform: uppercase;
-      font-weight: bold;
-      font-size: 0.8em;
-      color: #888;
-      &:hover {
-        color: #888;
+.pro-pill {
+  font-weight: 600;
+}
+
+.logged-in-menu a,
+.logged-in-menu__signout-link a {
+  .alaveteli-pro & {
+    .no-js & {
+      &:hover,
+      &:active,
+      &:focus {
+        background: rbga(0,0,0,0.2);
       }
+    }
+  }
+  .no-js & {
+    &:hover,
+    &:active,
+    &:focus {
+      text-decoration: none;
     }
   }
 }
@@ -368,54 +418,28 @@ a.link_button_green_large {
   border-color: $action-color;
 }
 
-.navigation .logged-in-menu a,
-.navigation .logged-in-menu__signout-link a {
-  @include respond-min( $main_menu-mobile_menu_cutoff ) {
-    color: $link-color;
-    background-color: transparent;
-    text-decoration: none;
-    &:hover,
-    &:active,
-    &:focus {
-      text-decoration: underline;
-    }
-  }
 
-  .logged-in-menu a,
-  .logged-in-menu__signout-link a {
-    color: $link-color;
-  }
-}
-
-
-/* LANGUAGE SWITCHER */
-#user_locale_switcher {
-  background-color: $color_primary;
-  @include respond-min($main_menu-mobile_menu_cutoff) {
-    background-color: transparent;
-  }
-}
-
-/* Dropdown list for switching locale */
+/* locale-list */
 .locale-list {
-  border-bottom: 0;
+  border-color: rgba(0, 0, 0, 0.15);
   @include respond-min($main_menu-mobile_menu_cutoff) {
-    position: absolute;
-    left: ($logo-width + 40px);
-    top: 2.2em;
-    right: auto;
+    position: relative;
+    top: 0.65em;
+    background-color: transparent;
+    left: -76px;
   }
-  .locale-list-trigger {
-    margin-bottom: 0;
+}
+
+p.locale-list-trigger {
+  x-margin-bottom: 10px;
+  color: $color_white;
+  color: rgba(255, 255, 255, 0.8);
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    margin-top: 0;
+    border: 1px solid desaturate(lighten($color_primary, 5%), 5%);
+    border-radius: 3px;
     color: $color_white;
-    color: transparentize($color_white, 0.8);
-    @include respond-min($main_menu-mobile_menu_cutoff) {
-      margin-top: 0;
-      border: 1px solid desaturate(lighten($color_primary, 5%), 5%);
-      border-radius: 3px;
-      color: $link-color;
-      padding: 0;
-    }
+    padding: 0;
   }
 }
 
@@ -427,22 +451,21 @@ a.link_button_green_large {
   @include respond-min($main_menu-mobile_menu_cutoff) {
     padding: 0.66em 2em 0.66em 0.66em;
   }
-}
-
-.locale-list-trigger .current-locale:after {
-  display: block;
-  position: absolute;
-  content: '';
-  right: 10px;
-  top: 12px;
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  @include ie8 {
-    border-top: 5px solid $color_white;
+  &:after {
+    display: block;
+    position: absolute;
+    content: '';
+    right: 10px;
+    top: 12px;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    @include ie8 {
+      border-top: 5px solid $color_white;
+    }
+    border-top: 5px solid rgba(255,255,255,0.4);
   }
-  border-top: 5px solid transparentize($color_white, 0.6);
 }
 
 .locale-list-trigger .current-locale,
@@ -458,27 +481,23 @@ a.link_button_green_large {
 
 .locale-list .available-languages {
   display: none;
-  padding: 0;
-  margin-bottom: 0;
-  margin-top: 0;
-  font-size: 0.8125em;
   @include respond-min($main_menu-mobile_menu_cutoff) {
     position: absolute;
-    top: 2em;
-    left: 0;
+    top: 3.4375em;
+    left: 0.9375em;
     z-index: 1000;
     border-radius: 3px;
     font-size: 1em;
-    min-width: 100%;
+    width: 100%;
+    max-width: 10em;
   }
-
 }
 
 .locale-list li {
   list-style-type: none;
-  border-bottom: 1px solid desaturate(lighten($color_primary, 3%), 5%);
+  border-top: 1px solid desaturate(lighten($color_primary, 5%), 5%);
   @include respond-min($main_menu-mobile_menu_cutoff) {
-    border-bottom-color: $color_neutral_dark;
+    border-color: $color_neutral_dark;
     display: block;
   }
   &:last-child {
@@ -495,19 +514,15 @@ a.link_button_green_large {
 .locale-list .available-languages a,
 .locale-list .available-languages a:link,
 .locale-list .available-languages a:visited {
-  display: block;
-  background-color: $color_primary;
-  padding: 0.66em 1em;
-  width: 100%;
   text-decoration: none;
-  color: transparentize($color_white, 0.2);
-  @include ie8 {
-    color: $color_white;
-  }
+  transition: background-color 0.5s ease-out;
+  color: #fff;
   @include respond-min($main_menu-mobile_menu_cutoff) {
     background-color: lighten($color_neutral_dark, 6%);
+    display: block;
+    padding: 0.5em 1em;
+    width: 100%;
   }
-  transition: background-color 0.5s ease-out;
 }
 
 .locale-list .available-languages a:hover,
@@ -518,22 +533,20 @@ a.link_button_green_large {
     background-color: $color_neutral_dark
   }
   color: $color_white;
-
 }
 
 /* JS interactivity */
-.no-js .locale-list .available-languages,
-.locale-list.active .available-languages {
-  display: block;
-}
+ .no-js .locale-list .available-languages,
+ .locale-list.active .available-languages {
+   display: block;
+ }
 
 .locale-list.active .current-locale {
-  background-color: $color_primary;
   color: $color_white;
   border-color: $color_primary;
   @include respond-min($main_menu-mobile_menu_cutoff) {
-    background-color: lighten($color_neutral_dark, 6%);
-    border-bottom: 1px solid lighten($color_neutral_dark, 2%);
+    background-color: darken($color_dark_grey, 10%);
+    border-color: lighten($color_neutral_dark, 2%);
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
@@ -543,14 +556,17 @@ a.link_button_green_large {
   @include ie8 {
     border-top-color: $color_white;
   }
-  border-top-color: transparentize($color_white, 0.6);
+  border-top-color: rgba(255,255,255,0.4);
 }
 
-
 .locale-list.active .locale-list-trigger {
-  border-color: transparent;
+  border-color: lighten($color_neutral_dark, 2%);
+}
+
+.locale-list .locale-list-trigger,
+.locale-list.active .locale-list-trigger {
   @include respond-min($main_menu-mobile_menu_cutoff) {
-    border-color: $color_neutral_dark;
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
ToDo:
- [x] recheck against actual release code
- [x] increase margin between account link and user menu per WDTK

Reimplements Martin's header changes for Transparencia. No longer requires navigation item translation changes.

Logged in Pro user with menu:
<img width="1064" alt="screen shot 2018-10-09 at 15 49 43" src="https://user-images.githubusercontent.com/27760/46677822-3ad34200-cbdb-11e8-8b3d-f9a4043fe596.png">

Logged in standard user with menu:
<img width="1066" alt="screen shot 2018-10-09 at 15 51 10" src="https://user-images.githubusercontent.com/27760/46677831-3dce3280-cbdb-11e8-9248-7f8abdf4d679.png">


Required by #77 
(Will merge this into the not-ready-yet release branch rather than master but ... the compare with master should work for review purposes.)