### PR TITLE
Remove UKCOD references

### DIFF
--- a/lib/views/help/about.html.erb
+++ b/lib/views/help/about.html.erb
@@ -24,7 +24,7 @@
     </dd>
 
     <dt id="who">Qui s'occupe de <%= site_name %> ? <a href="#who">#</a> </dt>
-    <dd><%= site_name %> est un projet <a href="https://www.anticor.be/">d’Anticor Belgique</a> développé en collaboration avec <a href="http://alaveteli.org">Alaveteli</a>, qui a été créée et est gérée par <a href="http://www.mysociety.org">mySociety</a>. mySociety est un projet de l'association <a href="http://www.ukcod.org.uk/UK_Citizens_Online_Democracy">UK Citizens Online Democracy</a>. Si vous aimez ce que fait Alaveteli, vous pouvez faire un don <a href="https://www.mysociety.org/donate/">ici</a>.
+    <dd><%= site_name %> est un projet <a href="https://www.anticor.be/">d’Anticor Belgique</a> développé en collaboration avec <a href="http://alaveteli.org">Alaveteli</a>, qui a été créée et est gérée par <a href="http://www.mysociety.org">mySociety</a>. Si vous aimez ce que fait Alaveteli, vous pouvez faire un don <a href="https://www.mysociety.org/donate/">ici</a>.
     <br><br>
     Vous pouvez également soutenir l’action d’Anticor en faisant un don sur le compte BE75 0017 9318 5951 - BIC : GEBABEBB au nom d’Anticor Belgique. Cet argent servira à couvrir les frais de gestion des projets “transparence” d’Anticor Belgique.
     </dd>

--- a/lib/views/help/about.nl.html.erb
+++ b/lib/views/help/about.nl.html.erb
@@ -23,7 +23,7 @@
     </dd>
 
     <dt id="who">Wie beheert <%= site_name %>? <a href="#who">#</a> </dt>
-    <dd><%= site_name %> is een project van <a href="https://www.anticor.be/">Anticor België</a> in samenwerking met <a href="http://alaveteli.org">Alaveteli</a>, die werd opgericht en beheerd wordt door <a href="http://www.mysociety.org">mySociety</a>. mySociety is een project van de vereniging <a href="http://www.ukcod.org.uk/UK_Citizens_Online_Democracy">UK Citizens Online Democracy</a>. Indien u ons werk nuttig vindt, kan u <a href="https://www.mysociety.org/donate/">hier</a> een gift doen.
+    <dd><%= site_name %> is een project van <a href="https://www.anticor.be/">Anticor België</a> in samenwerking met <a href="http://alaveteli.org">Alaveteli</a>, die werd opgericht en beheerd wordt door <a href="http://www.mysociety.org">mySociety</a>. Indien u ons werk nuttig vindt, kan u <a href="https://www.mysociety.org/donate/">hier</a> een gift doen.
     <br><br>
     U kan de werking van Anticor België ook steunen door een gift te doen op rekeningnummer BE75 0017 9318 5951 - BIC: GEBABEBB op naam van Anticor België. Dit geld zal dienen om de werkingskosten te dekken van het project "transparentie" van Anticor België.
     </dd>


### PR DESCRIPTION
UKCOD is now formally known as mySociety so we don't need to mention UK Citizens Online Democracy any more.