### PR TITLE
Add CADA appeal document download option

### DIFF
--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -20,4 +20,8 @@ Rails.application.routes.draw do
           :as => :signchangeprovince,
           :via => [:get, :post]
   end
+
+  match '/request/:url_title/download_saisine' => 'request#download_entire_request_saisine',
+        :as => :download_entire_request_saisine,
+        :via => :get
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -98,4 +98,91 @@ Rails.configuration.to_prepare do
                                  :password_confirmation, :province, :postcode)
     end
   end
+
+  RequestController.class_eval do
+    # Note that the rendered file is cached, so clear the cached version
+    # if you update this code!
+    def download_entire_request_saisine
+      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
+      # Check for access and hide embargoed requests immediately, so that we
+      # don't leak any info to people who can't access them
+      render_hidden if @info_request.embargo && cannot?(:read, @info_request)
+      if !authenticated?
+        ask_to_login(
+          web: _('To download the zip file'),
+          email: _('Then you can download a zip file of ' \
+                   '{{info_request_title}}.',
+                   info_request_title: @info_request.title),
+          email_subject: _('Log in to download a zip file of ' \
+                           '{{info_request_title}}',
+                           info_request_title: @info_request.title)
+        )
+      else
+        # Test for whole request being hidden or requester-only
+        return render_hidden if cannot?(:read, @info_request)
+
+        cache_file_path = @info_request.make_zip_cache_path_for_saisine(@user)
+        unless File.exist?(cache_file_path)
+          FileUtils.mkdir_p(File.dirname(cache_file_path))
+          make_request_zip_for_saisine(@info_request, cache_file_path)
+          File.chmod(0o644, cache_file_path)
+        end
+        send_file(cache_file_path, filename: "saisine_cada_#{params[:url_title]}.zip")
+      end
+    end
+
+    def make_request_zip_for_saisine(info_request, file_path)
+      Zip::File.open(file_path, create: true) do |zipfile|
+        file_info = make_request_summary_file_for_saisine(info_request)
+        zipfile.get_output_stream(file_info[:filename]) { |f| f.write(file_info[:data]) }
+        message_index = 0
+        info_request.incoming_messages.each do |message|
+          next unless can?(:read, message)
+
+          message_index += 1
+          message.get_attachments_for_display.each do |attachment|
+            filename = "#{message_index}_#{attachment.url_part_number}_#{attachment.display_filename}"
+            zipfile.get_output_stream(filename) do |f|
+              body = message.apply_masks(attachment.default_body, attachment.content_type)
+              f.write(body)
+            end
+          end
+        end
+      end
+    end
+
+    def make_request_summary_file_for_saisine(info_request)
+      done = false
+      @render_to_file = true
+      assign_variables_for_show_template(info_request)
+      if HTMLtoPDFConverter.exist?
+        html_output = render_to_string(template: 'request/show', variant: :cada)
+        tmp_input = Tempfile.new(['foihtml2pdf-input', '.html'])
+        tmp_input.write(html_output)
+        tmp_input.close
+        tmp_output = Tempfile.new('foihtml2pdf-output')
+        command = HTMLtoPDFConverter.new(tmp_input, tmp_output)
+        output = command.run
+        if !output.nil?
+          file_info = { filename: "correspondance_#{info_request.url_title}.pdf",
+                        data: File.open(tmp_output.path).read }
+          done = true
+        else
+          logger.error("Could not convert info request #{info_request.id} to PDF with command '#{command}'")
+        end
+        tmp_output.close
+        tmp_input.delete
+        tmp_output.delete
+      else
+        logger.warn('No HTML -> PDF converter found')
+      end
+      unless done
+        file_info = { filename: 'correspondance.txt',
+                      data: render_to_string(template: 'request/show',
+                                             layout: false,
+                                             formats: [:text]) }
+      end
+      file_info
+    end
+  end
 end

--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -20,6 +20,34 @@ Rails.configuration.to_prepare do
   #     "If you uncomment this line, this text will appear as default text in every message"
   #   end
   # end
+  #
+  InfoRequest.class_eval do
+    def make_zip_cache_path_for_saisine(user)
+      # This method is only used for the saisine CADA PDF doc.
+      # The filename needs to be different from the "regular" PDF as the content
+      # of this one is different. This prevents the cache from returning the wrong
+      # file, should users request both files.
+      # The zip file varies depending on user because it can include different
+      # messages depending on whether the user can access hidden or
+      # requester_only messages. We name it appropriately, so that every user
+      # with the right permissions gets a file with only the right things in it.
+      cache_file_dir = File.join(InfoRequest.download_zip_dir,
+                                 'download',
+                                 request_dirs,
+                                 last_update_hash)
+      cache_file_suffix = zip_cache_file_suffix(user)
+      File.join(cache_file_dir, "saisine_#{url_title}#{cache_file_suffix}.zip")
+    end
+
+    # extra translation that will not appear in transifex
+    def link_text_for_appeal_document
+      if FastGettext.locale == 'nl_BE'
+        'Download een zip bestand (voor een beroep bij CTB)'
+      else
+        'Télécharger un fichier zip pour votre recours CADA'
+      end
+    end
+  end
 
   User.class_eval do
     strip_attributes only: [:province, :postcode]

--- a/lib/views/comment/_single_comment.html+cada.erb
+++ b/lib/views/comment/_single_comment.html+cada.erb
@@ -1,0 +1,1 @@
+<!-- This template is intentionally left empty to prevent rendering comments on saisine docs -->

--- a/lib/views/request/_after_actions.html.erb
+++ b/lib/views/request/_after_actions.html.erb
@@ -1,0 +1,106 @@
+<div id="after_actions" class="after-actions">
+  <ul class="action-menu after-actions__action-menu">
+    <li>
+      <a href="#" class="action-menu__button"><%= _('Actions') %></a>
+
+      <ul class="action-menu__menu">
+        <% unless info_request.is_external? %>
+          <li class="action-menu__menu__item">
+            <span class="action-menu__menu__heading">
+              <%= _('{{info_request_user_name}}',
+                    :info_request_user_name => h(info_request.user_name)) %>
+            </span>
+
+            <ul class="action-menu__menu__submenu owner_actions">
+              <li>
+                <% if last_response.nil? %>
+                  <%= link_to _('Send a followup'), new_request_followup_path(request_id: info_request.id) %>
+                <% else %>
+                  <%= link_to _('Write a reply'), new_request_incoming_followup_path(request_id: info_request.id, incoming_message_id: last_response.id) %>
+                <% end %>
+              </li>
+
+              <% if show_owner_update_status_action %>
+                <li>
+                  <%= link_to _('Update the status of this request'), request_path(info_request, update_status: 1) %>
+                </li>
+              <% end %>
+
+              <li>
+                <%= link_to _('Request an internal review'), new_request_followup_path(request_id: info_request.id, internal_review: '1') %>
+              </li>
+            </ul>
+          </li>
+        <% end %>
+
+        <li class="action-menu__menu__item">
+          <span class="action-menu__menu__heading">
+            <%= _('{{public_body_name}}',
+                  :public_body_name => h(info_request.public_body.name)) %>
+          </span>
+
+          <ul class="action-menu__menu__submenu public_body_actions">
+            <li>
+              <%= link_to _("Respond to request"), upload_response_path(:url_title => info_request.url_title) %>
+            </li>
+          </ul>
+        </li>
+
+        <li class="action-menu__menu__item">
+          <ul class="action-menu__menu__submenu anyone_actions">
+
+            <% if info_request.attention_requested %>
+              <%# The request has already been reported %>
+              <li>
+                <%=  _("Report this request") %>
+                <span class="action-menu__info-link">
+                  <%= link_to _("Unavailable"), help_about_path(:anchor => "reporting_unavailable") %>
+                </span>
+              </li>
+            <% else %>
+              <li>
+               <%= link_to _("Report this request"), new_request_report_path(:request_id => info_request.url_title) %><span class="action-menu__info-link">
+                <%= link_to _("Help"), help_about_path(:anchor => "reporting") %>
+              </span>
+              </li>
+            <% end %>
+
+            <% if feature_enabled?(:annotations) && info_request.comments_allowed? %>
+              <li>
+                <%= link_to _('Add an annotation'), new_comment_path(:url_title => info_request.url_title) %>
+              </li>
+            <% end %>
+
+            <% if show_other_user_update_status_action %>
+              <li>
+                <%= link_to _('Update the status of this request'), '#describe_state_form_1' %>
+              </li>
+            <% end %>
+
+            <li>
+              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => info_request.url_title) %>
+            </li>
+
+            <li>
+              <%= link_to info_request.link_text_for_appeal_document, download_entire_request_saisine_path(:url_title => info_request.url_title) %>
+            </li>
+
+            <li>
+              <%= link_to _('View event history details'), request_details_path(info_request) %>
+            </li>
+
+            <li>
+              <a tabindex="0" class="js-collapsable-trigger-all" data-text-expanded="<%= _('Collapse all correspondence') %>" data-text-collapsed="<%= _('Expand all correspondence') %>"><%= _('Collapse all correspondence') %></a>
+            </li>
+
+            <li>
+              <%= render :partial => 'track/rss_feed',
+                         :locals => { :track_thing => track_thing,
+                                      :location => 'action-menu' } %>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</div>

--- a/lib/views/request/_incoming_correspondence.html+cada.erb
+++ b/lib/views/request/_incoming_correspondence.html+cada.erb
@@ -14,7 +14,7 @@
     <% end %>
 
     <div>
-        (Reçu de: <%= incoming_message.from_email %> sur <%= @info_request.incoming_email %>)
+      (<%=_('From:')%> <%= incoming_message.from_email %> <%=_('To:')%> <%= @info_request.incoming_email %>)
     </div>
   </div>
 

--- a/lib/views/request/_incoming_correspondence.html+cada.erb
+++ b/lib/views/request/_incoming_correspondence.html+cada.erb
@@ -1,0 +1,52 @@
+<div class="incoming correspondence <%= incoming_message.prominence %> js-collapsable" id="<%= dom_id(incoming_message) %>">
+  <div class="correspondence__header">
+    <span class="correspondence__header__author js-collapsable-trigger">
+      <% if incoming_message.specific_from_name? %>
+        <%= incoming_message.safe_from_name %>,
+      <% end %>
+      <% if incoming_message.from_public_body? %>
+        <%= @info_request.public_body.name %>
+      <% end %>
+    </span>
+
+    <%= link_to incoming_message_path(incoming_message, anchor_only: true), :class => 'correspondence__header__date' do %>
+      <%= simple_date(incoming_message.sent_at) %> - <%= simple_time(incoming_message.sent_at) %>
+    <% end %>
+
+    <div>
+        (Reçu de: <%= incoming_message.from_email %> sur <%= @info_request.incoming_email %>)
+    </div>
+  </div>
+
+    <%= render partial: 'request/prominence', locals: { prominenceable: incoming_message } %>
+
+  <%- if can?(:read, incoming_message) %>
+    <% if feature_enabled?(:refusal_identification) %>
+      <%= render partial: 'request/incoming_refusals',
+                 locals: { incoming_message: incoming_message } %>
+    <% end %>
+
+    <div class="correspondence_text">
+      <%= render partial: 'request/attachments',
+                 locals: { incoming_message: incoming_message } %>
+    </div>
+
+    <p class="event_actions">
+      <% if !@user.nil? && @user.admin_page_links? %>
+        <%= link_to "Admin", edit_admin_incoming_message_path(incoming_message.id) %>
+      <% end %>
+    </p>
+
+    <% if show_correspondence_footer %>
+      <% link_to_this_url = incoming_message_url(incoming_message) %>
+
+      <% report_path =
+           new_request_report_path(request_id: @info_request.url_title,
+                                   incoming_message_id: incoming_message.id) %>
+
+      <%= render partial: 'request/correspondence_footer',
+                 locals: { link_to_this_url: link_to_this_url,
+                           report_path: report_path } %>
+    <% end %>
+  <%- end %>
+</div>

--- a/lib/views/request/_outgoing_correspondence.html+cada.erb
+++ b/lib/views/request/_outgoing_correspondence.html+cada.erb
@@ -1,0 +1,57 @@
+<div class="outgoing correspondence js-collapsable" id="<%= dom_id(outgoing_message) %>">
+  <%= render partial: 'request/prominence', locals: { prominenceable: outgoing_message } %>
+
+  <%- if can?(:read, outgoing_message) %>
+    <% delivery_status = outgoing_message.delivery_status %>
+
+    <div class="correspondence__header <% if delivery_status %>correspondence__header--with-delivery-status<% end %>">
+      <span class="correspondence__header__author js-collapsable-trigger">
+        <%= @info_request.user_name %> (De: <%= @info_request.incoming_email %> À: <%= @info_request.recipient_email %>)
+      </span>
+
+      <%= link_to outgoing_message_path(outgoing_message), :class => 'correspondence__header__date' do %>
+          <%= simple_date(outgoing_message.last_sent_at) %> - <%= simple_time(outgoing_message.last_sent_at) %>
+      <% end %>
+
+      <% if delivery_status %>
+        <div class="correspondence__header__delivery-status">
+          <%= link_to outgoing_message_delivery_status_path(outgoing_message), class: "toggle-delivery-log toggle-delivery-log--#{outgoing_message.delivery_status.to_s} js-toggle-delivery-log", data: { delivery_status: outgoing_message.delivery_status.to_s } do -%>
+            <%= _(outgoing_message.delivery_status.to_s!.humanize) -%>
+          <% end -%>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="js-delivery-log-ajax-error" hidden aria-hidden="true" style="display: none; visibility: hidden;">
+      <p><%= _('We couldn’t load the mail server logs for this message.') %></p>
+      <p><%= link_to _('Try opening the logs in a new window.'), outgoing_message_delivery_status_path(outgoing_message), :target => '_blank' %></p>
+    </div>
+
+    <div class="correspondence_text">
+      <div><%= outgoing_message.get_body_for_html_display %></div>
+    </div>
+
+    <p class="event_actions">
+      <% if outgoing_message.status == 'ready' && !@info_request.is_external? %>
+        <%= _('<strong>Warning:</strong> This message has <strong>not yet ' \
+                 'been sent</strong> for an unknown reason.') %>
+      <% end %>
+
+      <% if !@user.nil? && @user.admin_page_links? %>
+        <%= link_to "Admin", edit_admin_outgoing_message_path(outgoing_message.id) %>
+      <% end %>
+    </p>
+
+    <% if show_correspondence_footer %>
+      <% link_to_this_url = outgoing_message_url(outgoing_message) %>
+
+      <% report_path =
+           new_request_report_path(request_id: @info_request.url_title,
+                                   outgoing_message_id: outgoing_message.id) %>
+
+      <%= render partial: 'request/correspondence_footer',
+                 locals: { link_to_this_url: link_to_this_url,
+                           report_path: report_path } %>
+    <% end %>
+  <%- end %>
+</div>

--- a/lib/views/request/_outgoing_correspondence.html+cada.erb
+++ b/lib/views/request/_outgoing_correspondence.html+cada.erb
@@ -6,7 +6,7 @@
 
     <div class="correspondence__header <% if delivery_status %>correspondence__header--with-delivery-status<% end %>">
       <span class="correspondence__header__author js-collapsable-trigger">
-        <%= @info_request.user_name %> (De: <%= @info_request.incoming_email %> À: <%= @info_request.recipient_email %>)
+        <%= @info_request.user_name %> (<%=_('From:')%> <%= @info_request.incoming_email %> <%=_('To:')%> <%= @info_request.recipient_email %>)
       </span>
 
       <%= link_to outgoing_message_path(outgoing_message), :class => 'correspondence__header__date' do %>

--- a/lib/views/request/_request_header.html+cada.erb
+++ b/lib/views/request/_request_header.html+cada.erb
@@ -1,0 +1,64 @@
+<div class="request-header">
+  <div class="row">
+    <h1><%= h(info_request.title) %></h1>
+
+    <h3 style="padding-left: 0.9375.rem">Demande d'accès à un document administratif : Récapitulatif des échanges demandeur-administration</h3>
+
+    <div class="request-header__action-bar-container">
+      <div class="request-header__action-bar">
+        <% if show_profile_photo %>
+          <div class=" request-header__profile-photo user_photo_on_request">
+            <img src="<%= get_profile_photo_url(url_name: info_request.user.url_name) %>" alt="">
+          </div>
+        <% end %>
+
+        <p class="request-header__subtitle <% if show_profile_photo %>request-header__subtitle--narrow<% end %>">
+          <%= render partial: 'request/request_subtitle',
+                     locals: { info_request: info_request,
+                               user: user } %>
+        </p>
+
+        <% if show_action_menu %>
+          <div class="request-header__action-bar__actions <% if show_profile_photo %>request-header__action-bar__actions--narrow<% end %>">
+            <% if in_pro_area %>
+              <%= render partial: 'alaveteli_pro/info_requests/after_actions',
+                         locals: { info_request: info_request,
+                                   last_response: last_response } %>
+            <% else %>
+              <%= render partial: 'request/after_actions',
+                         locals: { info_request: info_request,
+                                   track_thing: track_thing,
+                                   show_owner_update_status_action: show_owner_update_status_action,
+                                   show_other_user_update_status_action: show_other_user_update_status_action,
+                                   last_response: last_response } %>
+
+              <%= render partial: 'track/tracking_links_simple',
+                         locals: { track_thing: track_thing,
+                                   user: user,
+                                   follower_count: follower_count,
+                                   own_request: info_request.user && \
+                                                info_request.user == user,
+                                   location: 'toolbar' } %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="request-status">
+      <div id="request_status" class="request-status-message request-status-message--<%= info_request.calculate_status %>">
+        <i class="icon-standalone icon_<%= info_request.calculate_status %>"></i>
+
+        <p>
+          <%= status_text(info_request,
+                          new_responses_count: new_responses_count,
+                          is_owning_user: is_owning_user,
+                          render_to_file: render_to_file,
+                          old_unclassified: old_unclassified,
+                          redirect_to: request.fullpath) %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/lib/views/request/request_subtitle/_batch.html+cada.erb
+++ b/lib/views/request/request_subtitle/_batch.html+cada.erb
@@ -1,0 +1,8 @@
+<!-- Never show the (admin) links on the saisine PDF document -->
+<%= _('{{user}} made this {{law_used_full}} request to {{public_body}} as ' \
+      'part of <a href="{{url}}">a batch sent to {{count}} authorities</a>',
+      user: request_user_link(info_request, _('An anonymous user')),
+      law_used_full: h(info_request.legislation.to_s(:full)),
+      public_body: public_body_link(info_request.public_body),
+      url: info_request_batch_path(info_request.info_request_batch),
+      count: info_request.info_request_batch.public_bodies.count) %>

--- a/lib/views/request/request_subtitle/_single.html+cada.erb
+++ b/lib/views/request/request_subtitle/_single.html+cada.erb
@@ -1,0 +1,5 @@
+<!-- Never show the (admin) links on the saisine PDF document -->
+<%= _('{{user}} made this {{law_used_full}} request to {{public_body}}',
+      user: request_user_link(info_request, _('An anonymous user')),
+      law_used_full: h(info_request.legislation.to_s(:full)),
+      public_body: public_body_link(info_request.public_body)) %>


### PR DESCRIPTION
This PR adds a download link option in the "actions" menu which will provide the user with an appeal document for the CADA. It is based on the model we use on madada.fr, which works well for the French appeal body.

It relies on a template variant (named `cada`) so that it does not affect the regular PDF export in any way. The only difference is that this one adds full timestamps and email addresses to the output, and hides some minor elements that should be of no interest for an appeal: comments, "admin" links, etc...

I simply copied the code I wrote a while back while on an older version of alaveteli, so it should just work for the Belgian site. Local tests work ok, except for a bug in the PDF rendering which is not specific to this export, but also affects the main one.