### PR TITLE
Show CADA appeal doc link to admins and requester only

### DIFF
--- a/lib/views/request/_after_actions.html.erb
+++ b/lib/views/request/_after_actions.html.erb
@@ -77,14 +77,14 @@
               </li>
             <% end %>
 
+            <% if @is_owning_user %>
+              <li>
+                <%= link_to info_request.link_text_for_appeal_document, download_entire_request_saisine_path(:url_title => info_request.url_title) %>
+              </li>
+            <% end %>
             <li>
               <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => info_request.url_title) %>
             </li>
-
-            <li>
-              <%= link_to info_request.link_text_for_appeal_document, download_entire_request_saisine_path(:url_title => info_request.url_title) %>
-            </li>
-
             <li>
               <%= link_to _('View event history details'), request_details_path(info_request) %>
             </li>


### PR DESCRIPTION
This PR modifies the template to make the appeal document link visible to admins and request owners only, and moves the link to before the "regular" document, as requested by Transparencia.